### PR TITLE
Fix recover v1 account

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -181,7 +181,6 @@ func FromSeed(seedBase58Encoded string) (Account, error) {
 func FromRecoveryPhrase(words []string, lang language.Tag) (Account, error) {
 	dict, err := getBIP39Dict(lang)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 

--- a/account/account.go
+++ b/account/account.go
@@ -179,9 +179,15 @@ func FromSeed(seedBase58Encoded string) (Account, error) {
 }
 
 func FromRecoveryPhrase(words []string, lang language.Tag) (Account, error) {
+	dict, err := getBIP39Dict(lang)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+
 	switch len(words) {
 	case recoveryPhraseV1Length:
-		b, err := twentyFourWordsToBytes(words)
+		b, err := twentyFourWordsToBytes(words, dict)
 		if err != nil {
 			return nil, err
 		}
@@ -206,11 +212,6 @@ func FromRecoveryPhrase(words []string, lang language.Tag) (Account, error) {
 
 		return NewAccountV1(core)
 	case recoveryPhraseV2Length:
-		dict, err := getBIP39Dict(lang)
-		if err != nil {
-			return nil, err
-		}
-
 		core, err := twelveWordsToByteswords(words, dict)
 		if err != nil {
 			return nil, err

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -259,3 +259,13 @@ func TestValidateAccountNumber(t *testing.T) {
 	err = ValidateAccountNumber(livenetDeprecatedAccount.accountNumber)
 	assert.NoError(t, err)
 }
+
+func TestRecoverV1Account(t *testing.T) {
+	sdk.Init(&sdk.Config{Network: sdk.Testnet})
+	acctFromPhrase, err := FromRecoveryPhrase(
+		strings.Split("為 廠 磨 燕 華 已 忍 罵 稍 桌 搜 事 伴 爐 調 拜 輝 荒 巡 只 僚 空 之 填", " "),
+		language.TraditionalChinese,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "fBHRe9f7g3vQgpyq8NGar3QVMfCSPNfDeKPYF5Maef6gCYKsP4", acctFromPhrase.AccountNumber())
+}

--- a/account/recovery_phrase.go
+++ b/account/recovery_phrase.go
@@ -45,7 +45,7 @@ func bytesToTwentyFourWords(input []byte) ([]string, error) {
 }
 
 // 24 words to 33 bytes
-func twentyFourWordsToBytes(words []string) ([]byte, error) {
+func twentyFourWordsToBytes(words []string, dict []string) ([]byte, error) {
 	if 24 != len(words) {
 		return nil, fmt.Errorf("number of words: %d expected: 24", len(words))
 	}
@@ -57,7 +57,7 @@ func twentyFourWordsToBytes(words []string) ([]byte, error) {
 	for _, word := range words {
 		n := -1
 	loop:
-		for i, bip := range bip39.English {
+		for i, bip := range dict {
 			if word == bip {
 				n = i
 				break loop

--- a/bitmark/client.go
+++ b/bitmark/client.go
@@ -90,7 +90,7 @@ func Offer(params *OfferParams) error {
 }
 
 func Respond(params *ResponseParams) (string, error) {
-	if params.Countersignature == "" {
+	if params.auth.Get("signature") == "" {
 		return "", errors.New("response not signed by receiver")
 	}
 

--- a/bitmark/structs.go
+++ b/bitmark/structs.go
@@ -7,14 +7,11 @@ package bitmark
 import (
 	"encoding/json"
 	"time"
-
-	"github.com/bitmark-inc/bitmark-sdk-go/asset"
 )
 
 type Bitmark struct {
 	ID          string         `json:"id"`
 	AssetID     string         `json:"asset_id"`
-	Asset       *asset.Asset   `json:"asset"`
 	LatestTxID  string         `json:"head_id"` // TODO: rename api field
 	Issuer      string         `json:"issuer"`
 	Owner       string         `json:"owner"`

--- a/tx/structs.go
+++ b/tx/structs.go
@@ -4,15 +4,10 @@
 // license that can be found in the LICENSE file.
 package tx
 
-import (
-	"github.com/bitmark-inc/bitmark-sdk-go/asset"
-)
-
 type Tx struct {
 	ID           string `json:"id"`
 	BitmarkID    string `json:"bitmark_id"`
 	AssetID      string `json:"asset_id"`
-	Asset        *asset.Asset
 	Owner        string `json:"owner"`
 	Status       string `json:"status"`
 	BlockNumber  int    `json:"block_number"`


### PR DESCRIPTION
- handle account recovery from 24-word Chinese words
- remove the unused field `Asset` in `Bitmark` and `Tx`
- disable offer without signing