### PR TITLE
CreatedAt of an Asset can be nil if it's not confirmed

### DIFF
--- a/asset/structs.go
+++ b/asset/structs.go
@@ -15,5 +15,5 @@ type Asset struct {
 	Status      string            `json:"status"`
 	BlockNumber int               `json:"block_number"`
 	Offset      int               `json:"offset"`
-	CreatedAt   time.Time         `json:"created_at"`
+	CreatedAt   *time.Time        `json:"created_at"`
 }

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -45,7 +45,7 @@ func (q *QueryTestSuite) TestGetAsset() {
 		Status:      "confirmed",
 		BlockNumber: 8696,
 		Offset:      8581,
-		CreatedAt:   createdAt,
+		CreatedAt:   &createdAt,
 	}
 	q.Equal(actual, expected)
 }


### PR DESCRIPTION
This will introduce a breaking change.