### PR TITLE
[asset] add a method to set fingerprint from a reader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Bitmark SDK for Golang
 
+## 2.1.1
+### Improvements:
+- Calculate fingerprint from `io.Reader`
+
 ## 2.1.0
 ### Features:
 - Account: create new account, generate Recovery Phrase, recover account from Recovery Phrase

--- a/asset/params.go
+++ b/asset/params.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"sort"
 	"strings"
@@ -81,6 +82,17 @@ func (r *RegistrationParams) SetFingerprintFromFile(name string) error {
 	}
 
 	return r.SetFingerprintFromData(content)
+}
+
+func (r *RegistrationParams) SetFingerprintFromReader(reader io.Reader) error {
+	h := sha3.New512()
+	if _, err := io.Copy(h, reader); err != nil {
+		return err
+	}
+
+	digest := h.Sum(nil)
+	r.Fingerprint = fmt.Sprintf("%02d%s", fingerprintTypeSHA3512, hex.EncodeToString(digest[:]))
+	return nil
 }
 
 func (r *RegistrationParams) SetFingerprintFromData(content []byte) error {

--- a/asset/params_test.go
+++ b/asset/params_test.go
@@ -5,9 +5,11 @@
 package asset
 
 import (
-	"github.com/stretchr/testify/assert"
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	sdk "github.com/bitmark-inc/bitmark-sdk-go"
 	"github.com/bitmark-inc/bitmark-sdk-go/account"
@@ -49,6 +51,20 @@ func TestSetFingerprintFromData(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = params.SetFingerprintFromData([]byte("hello world"))
+	assert.NoError(t, err)
+	assert.Equal(t, params.Fingerprint, "01840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a")
+
+	err = params.SetFingerprintFromData(nil)
+	assert.Error(t, err, ErrEmptyContent.Error())
+}
+
+func TestSetFingerprintFromReader(t *testing.T) {
+	r := bytes.NewReader([]byte("hello world"))
+
+	params, err := NewRegistrationParams("", nil)
+	assert.NoError(t, err)
+
+	err = params.SetFingerprintFromReader(r)
 	assert.NoError(t, err)
 	assert.Equal(t, params.Fingerprint, "01840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a")
 


### PR DESCRIPTION
This PR adds a new method to allow users set fingerprint from an `io.Reader`.