### PR TITLE
Sort the hash array by ascending order before computing merkle tree

### DIFF
--- a/asset/params.go
+++ b/asset/params.go
@@ -5,6 +5,7 @@
 package asset
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -136,6 +137,10 @@ func (r *RegistrationParams) SetFingerprintFromDataArray(contents [][]byte) erro
 }
 
 func (r *RegistrationParams) setFingerprintFromHashes(hashes [][]byte) error {
+
+	// sort hash array by ascending order
+	sort.Slice(hashes, func(i, j int) bool { return bytes.Compare(hashes[i], hashes[j]) == -1 })
+
 	tree := buildMerkleTree(hashes, func(left, right []byte) []byte {
 		data := append(left, right...)
 		hash := sha3.Sum512(data)

--- a/asset/params_test.go
+++ b/asset/params_test.go
@@ -89,9 +89,13 @@ func TestSetFingerprintFromDataArrays(t *testing.T) {
 	params, err := NewRegistrationParams("", nil)
 	assert.NoError(t, err)
 
-	err = params.SetFingerprintFromDataArray([][]byte{[]byte("hello world"), []byte("this is a test case"), []byte("bitmark golang sdk")})
+	err = params.SetFingerprintFromDataArray([][]byte{
+		[]byte("hello world"),
+		[]byte("this is a test case"),
+		[]byte("bitmark sdk"),
+	})
 	assert.NoError(t, err)
-	assert.Equal(t, params.Fingerprint, "02ebzLDfLZ3j0VPfLh6n8ggb7Tp0Y4G0rLCeGqa7EgbRyqngnz1crLgHotJXpgKMZOupxm2YiuTbIQSTJ0UjC5hQ==")
+	assert.Equal(t, params.Fingerprint, "02DrQYWKFmh9APficsuetD/TlVwa5z4x3OoFVjk3f12RaRy8Wx3OhRTTVMLZPGImmgxZawOf++Xegq8t2p6pHe9w==")
 
 	err = params.SetFingerprintFromDataArray([][]byte{})
 	assert.Error(t, err, ErrEmptyContent.Error())
@@ -104,9 +108,13 @@ func TestSetFingerprintFromReaders(t *testing.T) {
 	params, err := NewRegistrationParams("", nil)
 	assert.NoError(t, err)
 
-	err = params.SetFingerprintFromReaders([]io.Reader{bytes.NewReader([]byte("hello world")), bytes.NewReader([]byte("this is a test case")), bytes.NewReader([]byte("bitmark golang sdk"))})
+	err = params.SetFingerprintFromReaders([]io.Reader{
+		bytes.NewReader([]byte("hello world")),
+		bytes.NewReader([]byte("this is a test case")),
+		bytes.NewReader([]byte("bitmark sdk")),
+	})
 	assert.NoError(t, err)
-	assert.Equal(t, params.Fingerprint, "02ebzLDfLZ3j0VPfLh6n8ggb7Tp0Y4G0rLCeGqa7EgbRyqngnz1crLgHotJXpgKMZOupxm2YiuTbIQSTJ0UjC5hQ==")
+	assert.Equal(t, params.Fingerprint, "02DrQYWKFmh9APficsuetD/TlVwa5z4x3OoFVjk3f12RaRy8Wx3OhRTTVMLZPGImmgxZawOf++Xegq8t2p6pHe9w==")
 
 	err = params.SetFingerprintFromReaders([]io.Reader{})
 	assert.Error(t, err, ErrEmptyContent.Error())


### PR DESCRIPTION
This PR adds canonical order of the input for computing fingerprint in case of multiple files/data. Following is detailed steps:
- Compute the SHA3512 array from underlying input.
- Sort the array by ascending order.
- Compute the fingerprint.

According the discussion [here](https://bitmark.slack.com/archives/C6JCKGCTY/p1611024801003800)